### PR TITLE
Add Terraform AWS Service Catalog example

### DIFF
--- a/terraform/service-catalog/README.md
+++ b/terraform/service-catalog/README.md
@@ -1,0 +1,11 @@
+# AWS Service Catalog Terraform Example
+
+This Terraform configuration provisions an AWS Service Catalog portfolio and
+product that deploys a simple S3 bucket using a CloudFormation template.
+
+## Usage
+
+1. Adjust the `region` variable in `variables.tf` if necessary.
+2. Run `terraform init` and `terraform apply` in this directory.
+
+The output values include the portfolio and product IDs created.

--- a/terraform/service-catalog/main.tf
+++ b/terraform/service-catalog/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_servicecatalog_portfolio" "main" {
+  name          = "ExamplePortfolio"
+  description   = "Service Catalog Portfolio"
+  provider_name = "IT Department"
+}
+
+resource "aws_servicecatalog_product" "s3_bucket" {
+  name        = "SimpleS3Bucket"
+  owner       = "IT Department"
+  description = "Provision a basic S3 bucket"
+  type        = "CLOUD_FORMATION_TEMPLATE"
+
+  provisioning_artifact_parameters {
+    name         = "v1"
+    type         = "CLOUD_FORMATION_TEMPLATE"
+    description  = "Initial version"
+    template_url = "file://${path.module}/templates/s3-bucket.yaml"
+  }
+}
+
+resource "aws_servicecatalog_portfolio_product_association" "assoc" {
+  portfolio_id = aws_servicecatalog_portfolio.main.id
+  product_id   = aws_servicecatalog_product.s3_bucket.id
+}

--- a/terraform/service-catalog/outputs.tf
+++ b/terraform/service-catalog/outputs.tf
@@ -1,0 +1,7 @@
+output "portfolio_id" {
+  value = aws_servicecatalog_portfolio.main.id
+}
+
+output "product_id" {
+  value = aws_servicecatalog_product.s3_bucket.id
+}

--- a/terraform/service-catalog/templates/s3-bucket.yaml
+++ b/terraform/service-catalog/templates/s3-bucket.yaml
@@ -1,0 +1,5 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Simple S3 bucket for Service Catalog
+Resources:
+  DemoBucket:
+    Type: AWS::S3::Bucket

--- a/terraform/service-catalog/variables.tf
+++ b/terraform/service-catalog/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region to deploy Service Catalog"
+  type        = string
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- add Service Catalog template for a simple S3 bucket
- provision portfolio, product, and association via Terraform

## Testing
- `terraform fmt -check terraform/service-catalog` *(fails: command not found)*